### PR TITLE
Add ASSERT_NOT_SUBSTRING() macro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ TEST(example)
 }
 ```
 
-Unicorn also provides the `ASSERT_SUBSTRING` macro. The assertion takes two strings as parameters and checks that the first one contains the second.
+Unicorn also provides the `ASSERT_SUBSTRING` and `ASSERT_NOT_SUBSTRING` macros. They both take two strings as parameters and check that the first one contains or doesn't contain the second respectively.
 
 ```c
 TEST(example)
@@ -297,6 +297,7 @@ TEST(example)
     /* ... */
 
     ASSERT_SUBSTRING(long_string, "Hello, world!");
+    ASSERT_NOT_SUBSTRING(empty_string, "Hello, world!");
 }
 ```
 

--- a/src/unicorn/assertion/assertion.h
+++ b/src/unicorn/assertion/assertion.h
@@ -82,6 +82,8 @@ bool unicorn_check_substring(char *string, char *substring);
 
 #define _UNICORN_CHECK_SUBSTRING(left, right) unicorn_check_substring(left, right)
 
+#define _UNICORN_CHECK_NOT_SUBSTRING(left, right) (!unicorn_check_substring(left, right))
+
 
 #define ASSERT_EQ(left, right) \
     _UNICORN_BINARY_ASSERTION(left, right, _UNICORN_CHECK_EQ, #left " == " #right, "First argument is equal to %s instead of %s.")
@@ -100,6 +102,9 @@ bool unicorn_check_substring(char *string, char *substring);
 
 #define ASSERT_SUBSTRING(string, substring) \
     _UNICORN_BINARY_ASSERTION(string, substring, _UNICORN_CHECK_SUBSTRING, "strstr(" #string ", " #substring ") != NULL", "First argument is equal to %s and doesn't contain %s.")
+
+#define ASSERT_NOT_SUBSTRING(string, substring) \
+    _UNICORN_BINARY_ASSERTION(string, substring, _UNICORN_CHECK_NOT_SUBSTRING, "strstr(" #string ", " #substring ") == NULL", "First argument is equal to %s and does contain %s.")
 
 
 #endif

--- a/src/unicorn/assertion/assertion.h
+++ b/src/unicorn/assertion/assertion.h
@@ -104,7 +104,7 @@ bool unicorn_check_substring(char *string, char *substring);
     _UNICORN_BINARY_ASSERTION(string, substring, _UNICORN_CHECK_SUBSTRING, "strstr(" #string ", " #substring ") != NULL", "First argument is equal to %s and doesn't contain %s.")
 
 #define ASSERT_NOT_SUBSTRING(string, substring) \
-    _UNICORN_BINARY_ASSERTION(string, substring, _UNICORN_CHECK_NOT_SUBSTRING, "strstr(" #string ", " #substring ") == NULL", "First argument is equal to %s and does contain %s.")
+    _UNICORN_BINARY_ASSERTION(string, substring, _UNICORN_CHECK_NOT_SUBSTRING, "strstr(" #string ", " #substring ") == NULL", "First argument is equal to %s and contains %s.")
 
 
 #endif

--- a/test/test_meta.c
+++ b/test/test_meta.c
@@ -211,7 +211,7 @@ TEST_PARAM(meta_test, struct { UnicornGroupItemRegistration handle; char *error;
     { meta_substring, .error = NULL },
     { meta_failing_substring, .error = "First argument is equal to \"Wrong value!\" and doesn't contain \"world\"." },
     { meta_not_substring, .error = NULL },
-    { meta_failing_not_substring, .error = "First argument is equal to \"Hello, world!\" and does contain \"world\"." },
+    { meta_failing_not_substring, .error = "First argument is equal to \"Hello, world!\" and contains \"world\"." },
 
     { meta_exit_success, .error = "Test process exited unexpectedly." },
     { meta_exit_failure, .error = "Test process exited unexpectedly." },

--- a/test/test_meta.c
+++ b/test/test_meta.c
@@ -150,6 +150,18 @@ TEST(meta_failing_substring)
     ASSERT_SUBSTRING(message, "world");
 }
 
+TEST(meta_not_substring)
+{
+    char *message = "Wrong value!";
+    ASSERT_NOT_SUBSTRING(message, "world");
+}
+
+TEST(meta_failing_not_substring)
+{
+    char *message = "Hello, world!";
+    ASSERT_NOT_SUBSTRING(message, "world");
+}
+
 TEST(meta_exit_success)
 {
     exit(EXIT_SUCCESS);
@@ -198,6 +210,8 @@ TEST_PARAM(meta_test, struct { UnicornGroupItemRegistration handle; char *error;
     { meta_failing_greater_equal, .error = "First argument -7 is not greater or equal to -2." },
     { meta_substring, .error = NULL },
     { meta_failing_substring, .error = "First argument is equal to \"Wrong value!\" and doesn't contain \"world\"." },
+    { meta_not_substring, .error = NULL },
+    { meta_failing_not_substring, .error = "First argument is equal to \"Hello, world!\" and does contain \"world\"." },
 
     { meta_exit_success, .error = "Test process exited unexpectedly." },
     { meta_exit_failure, .error = "Test process exited unexpectedly." },


### PR DESCRIPTION
Testing that a string is not part of a string is sometimes useful.